### PR TITLE
fix: fix use utf_slice to use utf8_slice

### DIFF
--- a/src/collections/string.md
+++ b/src/collections/string.md
@@ -110,7 +110,7 @@ You can use [utf8_slice](https://docs.rs/utf8_slice/1.0.0/utf8_slice/fn.slice.ht
 
 **Example**
 ```rust
-use utf_slice;
+use utf8_slice;
 fn main() {
    let s = "The 🚀 goes to the 🌑!";
 

--- a/src/compound-types/string.md
+++ b/src/compound-types/string.md
@@ -254,7 +254,7 @@ You can use [utf8_slice](https://docs.rs/utf8_slice/1.0.0/utf8_slice/fn.slice.ht
 
 **Example**
 ```rust
-use utf_slice;
+use utf8_slice;
 fn main() {
    let s = "The 🚀 goes to the 🌑!";
 

--- a/zh-CN/src/collections/String.md
+++ b/zh-CN/src/collections/String.md
@@ -113,7 +113,7 @@ fn main() {
 
 **示例**
 ```rust
-use utf_slice;
+use utf8_slice;
 fn main() {
    let s = "The 🚀 goes to the 🌑!";
 

--- a/zh-CN/src/compound-types/string.md
+++ b/zh-CN/src/compound-types/string.md
@@ -245,7 +245,7 @@ fn main() {
 
 **Example**
 ```rust
-use utf_slice;
+use utf8_slice;
 fn main() {
    let s = "The 🚀 goes to the 🌑!";
 


### PR DESCRIPTION
fix `use utf_slice` to `use utf8_slice`