### PR TITLE
🐞 fix(method.md): 缺少空白 / miss blank

### DIFF
--- a/en/src/method.md
+++ b/en/src/method.md
@@ -174,7 +174,7 @@ impl TrafficLight {
     }
 
     // fill in the blank, DON'T use any variants of `Self`
-    pub fn change_state() {
+    pub fn change_state(__) {
         self.color = "green".to_string()
     }
 }

--- a/zh-CN/src/method.md
+++ b/zh-CN/src/method.md
@@ -168,7 +168,7 @@ impl TrafficLight {
     }
 
     // 填空，不要使用 `Self` 或其变体
-    pub fn change_state() {
+    pub fn change_state(__) {
         self.color = "green".to_string()
     }
 }


### PR DESCRIPTION
练习 3 中，第 12 行， 函数参数应该有两个下划线表示空缺。

---

In Exercise 3, line 12, function arguments should have two underscores to indicate that they are empty.