### PR TITLE
Make first HashMap code segment editable

### DIFF
--- a/en/src/collections/hashmap.md
+++ b/en/src/collections/hashmap.md
@@ -9,7 +9,7 @@ The hash table implementation is a Rust port of Google’s [SwissTable](https://
 ### Basic Operations
 1. 🌟🌟
 
-```rust,editbale
+```rust,editable
 
 // FILL in the blanks and FIX the erros
 use std::collections::HashMap;


### PR DESCRIPTION
A spelling mistake is preventing the first HashMap challenge from being editable.