### PR TITLE
更新本地运行此电子书的说明，在win 10系统中须指定ip地址

### DIFF
--- a/zh-CN/src/why-exercise.md
+++ b/zh-CN/src/why-exercise.md
@@ -26,7 +26,10 @@
 $ cargo install mdbook
 $ cd rust-by-practice && mdbook serve 
 ```
-
+在本地win 10或者linux服务器上运行时，应当使用 -n 参数指定mdbook服务所监听的IP地址（-p 参数指定服务监听的端口，不指定则为默认的3000），以win 10本地运行为例：
+```shell
+$ mdbook serve -p 8888 -n 127.0.0.1
+```
 ## 特性
 
 部分示例和习题借鉴了 [Rust By Example](https://github.com/rust-lang/rust-by-example), 书中的示例真的非常棒！


### PR DESCRIPTION
在win 10系统中，如果不加-n参数指定本地服务的ip地址，则服务监听的ip为空，无法通过浏览器访问。信息如下：

>mdbook serve
2022-07-14 17:36:59 [INFO] (mdbook::book): Book building has started
2022-07-14 17:36:59 [INFO] (mdbook::book): Running the html backend
2022-07-14 17:36:59 [INFO] (mdbook::cmd::serve): Serving on: http://localhost:3000
2022-07-14 17:36:59 [INFO] (warp::server): Server::run; addr=[::1]:3000
2022-07-14 17:36:59 [INFO] (warp::server): listening on http://[::1]:3000
2022-07-14 17:36:59 [INFO] (mdbook::cmd::watch): Listening for changes...