### PR TITLE
fix: avoid unused variable warning

### DIFF
--- a/en/src/basic-types/functions.md
+++ b/en/src/basic-types/functions.md
@@ -85,7 +85,7 @@ fn main() {
     // FILL in the blank
     let b = __;
 
-    let v = match b {
+    let _v = match b {
         true => 1,
         // Diverging functions can also be used in match expression to replace a value of any value
         false => {

--- a/solutions/basic-types/functions.md
+++ b/solutions/basic-types/functions.md
@@ -108,7 +108,7 @@ fn main() {
     // FILL in the blank
     let b = false;
 
-    let v = match b {
+    let _v = match b {
         true => 1,
         // Diverging functions can also be used in match expression
         false => {

--- a/zh-CN/src/basic-types/functions.md
+++ b/zh-CN/src/basic-types/functions.md
@@ -77,7 +77,7 @@ fn main() {
     // 填空
     let b = __;
 
-    let v = match b {
+    let _v = match b {
         true => 1,
         // 发散函数也可以用于 `match` 表达式，用于替代任何类型的值
         false => {


### PR DESCRIPTION
The statements problem and solution produce an unrelated warning on Rust 1.62 .

```
   Compiling playground v0.0.1 (/playground)
warning: unused variable: `v`
 --> src/main.rs:5:9
  |
5 |     let v = match b {
  |         ^ help: if this is intentional, prefix it with an underscore: `_v`
  |
  = note: `#[warn(unused_variables)]` on by default

warning: `playground` (bin "playground") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.57s
     Running `target/debug/playground`
thread 'main' panicked at 'we have no value for `false`, but we can panic', src/main.rs:10:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Success!
```
