### PR TITLE
fix: provide solution that satisfies requirement

### DIFF
--- a/solutions/generics-traits/traits.md
+++ b/solutions/generics-traits/traits.md
@@ -225,11 +225,11 @@ impl Animal for Cow {
 
 // Returns some struct that implements Animal, but we don't know which one at compile time.
 // FIX the erros here, you can make a fake random, or you can use trait object
-fn random_animal(random_number: f64) -> impl Animal {
+fn random_animal(random_number: f64) -> Box<dyn Animal> {
     if random_number < 0.5 {
-        Sheep {}
+        Box::new(Sheep {})
     } else {
-        Sheep {}
+        Box::new(Cow {})
     }
 }
 


### PR DESCRIPTION
The specification says we have to return something that implements
Animal, but can't tell which at compile time.  The existing solution
only returns one concrete type Sheep, while the intent was to return
either Sheep or Cow.  This requires type erasure that can only be done
with a reference to dyn trait.