### PR TITLE
Update String.md

### DIFF
--- a/solutions/collections/String.md
+++ b/solutions/collections/String.md
@@ -32,7 +32,7 @@ fn main() {
 }
 
 fn borrow_string(s: &str) {
-    println!("ownership of \"{}\" is moved here!", s)
+    println!("ownership of \"{}\" is still with the variable 's', only the reference is passed", s)
 }
 ```
 


### PR DESCRIPTION
borrow_string() takes in &str so the value won't be moved into it. hence updated the message inside println!()