### PR TITLE
fix typo from edtiable to editable

### DIFF
--- a/en/src/formatted-output/formatting.md
+++ b/en/src/formatted-output/formatting.md
@@ -3,7 +3,7 @@
 ## Positional arguments
 
 1.🌟🌟
-```rust,edtiable
+```rust,editable
 
 /* Fill in the blanks */
 fn main() {


### PR DESCRIPTION
this error make the exercise 1 editable of formatting in chapter 16 of rust practice.