### PR TITLE
Fixed wrong print.

### DIFF
--- a/en/src/pattern-match/patterns.md
+++ b/en/src/pattern-match/patterns.md
@@ -15,7 +15,7 @@ fn match_number(n: i32) {
             println!("match 6 -> 10")
         },
         _ => {
-            println!("match 11 -> +infinite")
+            println!("match -infinite -> 0 or 11 -> +infinite")
         }
     }
 }


### PR DESCRIPTION
Since we are matching an i32 negative values will be matched too in the _ (default) branch.