### PR TITLE
修复字符串练习中的失效链接

### DIFF
--- a/zh-CN/src/collections/String.md
+++ b/zh-CN/src/collections/String.md
@@ -30,7 +30,7 @@ fn move_ownership(s: String) {
 
 而 `&str` 是[切片引用](https://course.rs/confonding/slice.html)类型( `&[u8]` )，指向一个合法的 UTF-8 字符序列，总之，`&str` 和 `String` 的关系类似于 `&[T]` 和 `Vec<T>` 。
 
-如果大家想了解更多，可以看看[易混淆概念解析 - &str 和 String](https://course.rs/confonding/string.html)。
+如果大家想了解更多，可以看看[易混淆概念解析 - &str 和 String](https://course.rs/difficulties/string.html)。
 
 
 2. 🌟🌟


### PR DESCRIPTION
修复字符串练习中的失效链接

解决issue: [https://github.com/sunface/rust-course/issues/1038](https://github.com/sunface/rust-course/issues/1038)