### PR TITLE
Adding an additional placeholder "__" on line 22 "Variables"

### DIFF
--- a/en/src/variables.md
+++ b/en/src/variables.md
@@ -19,7 +19,7 @@ fn main() {
 
 // Fill the blanks in the code to make it compile
 fn main() {
-    let __ = 1;
+    let __ __ = 1;
     __ += 2; 
     
     assert_eq!(x, 3);


### PR DESCRIPTION
Currently, on line 22 ["Variables"](https://practice.rs/variables.html), second code block,
 there is only a single placeholder "__", 
 whereas the correct answer requires two replies, namely "mut" and "x"

hence an extra "__" is added

line 22 :
current  :      let __ = 1;
propose :     let __ __ = 1;

Correct answer :  let mut x = 1;

cheers