### PR TITLE
fix: misleading words

### DIFF
--- a/en/src/compound-types/string.md
+++ b/en/src/compound-types/string.md
@@ -155,6 +155,7 @@ fn main() {
 /* Fill in the blank and fix the errors */
 fn main() {
     let raw_str = r"Escapes don't work here: \x3F \u{211D}";
+    // Modify above line to make it work
     assert_eq!(raw_str, "Escapes don't work here: ? ℝ");
 
     // If you need quotes in a raw string, add a pair of #s
@@ -166,6 +167,7 @@ fn main() {
     let  delimiter = r###"A string with "# in it. And even "##!"###;
     println!("{}", delimiter);
 
+    // Fill the blank
     let long_delimiter = __;
     assert_eq!(long_delimiter, "Hello, \"##\"");
 

--- a/solutions/compound-types/string.md
+++ b/solutions/compound-types/string.md
@@ -155,7 +155,7 @@ fn main() {
 ```rust
 fn main() {
     let raw_str = "Escapes don't work here: \x3F \u{211D}";
-    // modify below line to make it work
+    // modify above line to make it work
     assert_eq!(raw_str, "Escapes don't work here: ? ℝ");
 
     // If you need quotes in a raw string, add a pair of #s
@@ -167,7 +167,7 @@ fn main() {
     let  delimiter = r###"A string with "# in it. And even "##!"###;
     println!("{}", delimiter);
 
-    // fill the blank
+    // Fill the blank
     let long_delimiter = r###"Hello, "##""###;
     assert_eq!(long_delimiter, "Hello, \"##\"")
 }

--- a/zh-CN/src/compound-types/string.md
+++ b/zh-CN/src/compound-types/string.md
@@ -149,6 +149,7 @@ fn main() {
 /* 填空并修复所有错误 */
 fn main() {
     let raw_str = r"Escapes don't work here: \x3F \u{211D}";
+    // 修改上面的行让代码工作
     assert_eq!(raw_str, "Escapes don't work here: ? ℝ");
 
     // 如果你希望在字符串中使用双引号，可以使用以下形式


### PR DESCRIPTION
题目没注释，答案有注释，但注释写的`// 修改下面一行`会误导人，我看了好久都没看出来哪里有问题，结果是要修改上面一行