### PR TITLE
fix: add and fix solution links

### DIFF
--- a/en/src/basic-types/functions.md
+++ b/en/src/basic-types/functions.md
@@ -98,4 +98,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/basic-types/functions.md)(under the solutions path), but only use it when you need it

--- a/en/src/basic-types/numbers.md
+++ b/en/src/basic-types/numbers.md
@@ -183,4 +183,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/basic-types/numbers.md)(under the solutions path), but only use it when you need it

--- a/en/src/compound-types/array.md
+++ b/en/src/compound-types/array.md
@@ -99,4 +99,4 @@ fn main() {
 
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/compound-types/array.md)(under the solutions path), but only use it when you need it

--- a/en/src/compound-types/enum.md
+++ b/en/src/compound-types/enum.md
@@ -208,4 +208,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/compound-types/enum.md)(under the solutions path), but only use it when you need it

--- a/en/src/compound-types/slice.md
+++ b/en/src/compound-types/slice.md
@@ -97,4 +97,4 @@ fn first_word(s: &str) -> &str {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/compound-types/slice.md)(under the solutions path), but only use it when you need it

--- a/en/src/compound-types/string.md
+++ b/en/src/compound-types/string.md
@@ -264,4 +264,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/compound-types/string.md)(under the solutions path), but only use it when you need it

--- a/en/src/compound-types/struct.md
+++ b/en/src/compound-types/struct.md
@@ -228,4 +228,4 @@ fn main() {
 } 
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/compound-types/struct.md)(under the solutions path), but only use it when you need it

--- a/en/src/compound-types/tuple.md
+++ b/en/src/compound-types/tuple.md
@@ -86,4 +86,4 @@ fn sum_multiply(nums: (i32, i32)) -> (i32, i32) {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/compound-types/tuple.md)(under the solutions path), but only use it when you need it

--- a/en/src/crate-module/crate.md
+++ b/en/src/crate-module/crate.md
@@ -106,4 +106,4 @@ After this step, there should be two crates in package `hello-package`: **a bina
 Yep, as you can see, the above package structure is very standard and is widely used in many Rust projects.
 
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice) (under the solutions path), but only use it when you need it :)
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/crate-module/crate.md) (under the solutions path), but only use it when you need it :)

--- a/en/src/crate-module/module.md
+++ b/en/src/crate-module/module.md
@@ -192,4 +192,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice) (under the solutions path), but only use it when you need it :)
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/crate-module/module.md) (under the solutions path), but only use it when you need it :)

--- a/en/src/crate-module/use-pub.md
+++ b/en/src/crate-module/use-pub.md
@@ -66,4 +66,4 @@ pub mod a {
 The full code of `hello-package` is [here](https://github.com/sunface/rust-by-practice/tree/master/practices/hello-package).
 
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice) (under the solutions path), but only use it when you need it :)
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/crate-module/use-pub.md) (under the solutions path), but only use it when you need it :)

--- a/en/src/fight-compiler/borrowing.md
+++ b/en/src/fight-compiler/borrowing.md
@@ -27,3 +27,4 @@ impl test {
 
 fn main() {}
 ```
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/fight-compiler/borrowing.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/formatted-output/debug-display.md
+++ b/en/src/formatted-output/debug-display.md
@@ -151,3 +151,5 @@ fn main() {
 }
 ```
 
+
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/formatted-output/debug-display.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/formatted-output/formatting.md
+++ b/en/src/formatted-output/formatting.md
@@ -180,3 +180,5 @@ fn main() {
     println!("Hello {{}}"); // => Hello {}
 }
 ```
+
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/formatted-output/formatting.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/formatted-output/println.md
+++ b/en/src/formatted-output/println.md
@@ -36,3 +36,5 @@ fn main() {
    __("Sunface!");
 }
 ```
+
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/formatted-output/println.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/functional-programing/closure.md
+++ b/en/src/functional-programing/closure.md
@@ -433,3 +433,4 @@ fn call_with_different_values() {
     assert_eq!(v2, 1);
 }
 ```
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/functional-programing/closure.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/functional-programing/iterator.md
+++ b/en/src/functional-programing/iterator.md
@@ -350,3 +350,5 @@ fn main() {
     );
 }
 ```
+
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/functional-programing/iterator.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/generics-traits/const-generics.md
+++ b/en/src/generics-traits/const-generics.md
@@ -142,4 +142,4 @@ pub trait IsTrue {}
 impl IsTrue for Assert<true> {}
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it :)
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/generics-traits/const-generics.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/generics-traits/generics.md
+++ b/en/src/generics-traits/generics.md
@@ -152,5 +152,5 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/generics-traits/generics.md)(under the solutions path), but only use it when you need it
 

--- a/en/src/generics-traits/trait-object.md
+++ b/en/src/generics-traits/trait-object.md
@@ -226,4 +226,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it :)
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/generics-traits/trait-object.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/generics-traits/traits.md
+++ b/en/src/generics-traits/traits.md
@@ -469,4 +469,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it :)
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/generics-traits/traits.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/lifetime/advance.md
+++ b/en/src/lifetime/advance.md
@@ -282,3 +282,5 @@ fn use_list(list: &List) {
     println!("{}", list.manager.text);
 }
 ```
+
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/lifetime/advance.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/lifetime/basic.md
+++ b/en/src/lifetime/basic.md
@@ -356,3 +356,4 @@ enum Either<'a> {
 
 fn main() {}
 ```
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/lifetime/basic.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/lifetime/static.md
+++ b/en/src/lifetime/static.md
@@ -195,3 +195,5 @@ fn print_g(t: &'static String) {
   println!("{}", t);
 }
 ```
+
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/lifetime/static.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/ownership/borrowing.md
+++ b/en/src/ownership/borrowing.md
@@ -183,4 +183,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/ownership/borrowing.md)(under the solutions path), but only use it when you need it

--- a/en/src/ownership/ownership.md
+++ b/en/src/ownership/ownership.md
@@ -167,4 +167,4 @@ fn main() {
 ```
 
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/ownership/ownership.md)(under the solutions path), but only use it when you need it

--- a/en/src/pattern-match/patterns.md
+++ b/en/src/pattern-match/patterns.md
@@ -116,4 +116,4 @@ fn main() {
 }
 ```
 
-> You can find the solutions [here](https://github.com/sunface/rust-by-practice)(under the solutions path), but only use it when you need it
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/pattern-match/patterns.md)(under the solutions path), but only use it when you need it

--- a/en/src/result-panic/panic.md
+++ b/en/src/result-panic/panic.md
@@ -109,3 +109,5 @@ If in your project you need to make the resulting binary as small as possible, y
 panic = 'abort'
 ```
 
+
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/result-panic/panic.md)(under the solutions path), but only use it when you need it :)

--- a/en/src/result-panic/result.md
+++ b/en/src/result-panic/result.md
@@ -210,3 +210,4 @@ fn main() -> Result<(), ParseIntError> {
     Ok(())
 }
 ```
+> You can find the solutions [here](https://github.com/sunface/rust-by-practice/blob/master/solutions/result-panic/result.md)(under the solutions path), but only use it when you need it :)

--- a/zh-CN/src/functional-programing/closure.md
+++ b/zh-CN/src/functional-programing/closure.md
@@ -49,3 +49,4 @@ fn call_with_different_values() {
     assert_eq!(v2, 1);
 }
 ```
+> 你可以在[这里](https://github.com/sunface/rust-by-practice/blob/master/solutions/functional-programing/closure.md)找到答案(在 solutions 路径下)

--- a/zh-CN/src/functional-programing/iterator.md
+++ b/zh-CN/src/functional-programing/iterator.md
@@ -1,2 +1,4 @@
 # Iterator
 
+
+> 你可以在[这里](https://github.com/sunface/rust-by-practice/blob/master/solutions/functional-programing/iterator.md)找到答案(在 solutions 路径下)

--- a/zh-CN/src/lifetime/advance.md
+++ b/zh-CN/src/lifetime/advance.md
@@ -283,3 +283,5 @@ fn use_list(list: &List) {
     println!("{}", list.manager.text);
 }
 ```
+
+> 你可以在[这里](https://github.com/sunface/rust-by-practice/blob/master/solutions/lifetime/advance.md)找到答案(在 solutions 路径下)

--- a/zh-CN/src/lifetime/basic.md
+++ b/zh-CN/src/lifetime/basic.md
@@ -335,3 +335,5 @@ enum Either<'a> {
 
 fn main() {}
 ```
+
+> 你可以在[这里](https://github.com/sunface/rust-by-practice/blob/master/solutions/lifetime/basic.md)找到答案(在 solutions 路径下)

--- a/zh-CN/src/lifetime/static.md
+++ b/zh-CN/src/lifetime/static.md
@@ -185,3 +185,5 @@ fn print_g(t: &'static String) {
   println!("{}", t);
 }
 ```
+
+> 你可以在[这里](https://github.com/sunface/rust-by-practice/blob/master/solutions/lifetime/static.md)找到答案(在 solutions 路径下)

--- a/zh-CN/src/result-panic/panic.md
+++ b/zh-CN/src/result-panic/panic.md
@@ -109,3 +109,5 @@ note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose bac
 panic = 'abort'
 ```
 
+
+> 你可以在[这里](https://github.com/sunface/rust-by-practice/blob/master/solutions/result-panic/panic.md)找到答案(在 solutions 路径下)

--- a/zh-CN/src/result-panic/result.md
+++ b/zh-CN/src/result-panic/result.md
@@ -208,3 +208,4 @@ fn main() -> Result<(), ParseIntError> {
     Ok(())
 }
 ```
+> 你可以在[这里](https://github.com/sunface/rust-by-practice/blob/master/solutions/result-panic/result.md)找到答案(在 solutions 路径下)


### PR DESCRIPTION
fix tow conditions
1) some practice pages don't contain links to their solution page
2) some contain links but these links target the repo URL (not the corresponding solution page)(often in the English version