### PR TITLE
Fix: solutions/formatted-output/formating.md the third question

### DIFF
--- a/solutions/formatted-output/formatting.md
+++ b/solutions/formatted-output/formatting.md
@@ -34,7 +34,7 @@ fn main() {
     println!("Hello {:1$}!", "x", 5); // =>  "Hello x    !"
 
     assert_eq!(format!("Hello {1:0$}!", 5, "x"), "Hello x    !");
-    assert_eq!(format!("Hello {:width$}!", "x", width = 5), "Hello x    !");
+    assert_eq!(format!("Hello {0:width$}!", "x", width = 5), "Hello x    !");
 
     println!("Success!")
 }


### PR DESCRIPTION
From
```js
assert_eq!(format!("Hello {:width$}!", "x", width = 5), "Hello x    !");
```
To
```js
assert_eq!(format!("Hello {0:width$}!", "x", width = 5), "Hello x    !");
```
