### PR TITLE
fix: zh-CN typo `pracitce.rs`

### DIFF
--- a/zh-CN/src/SUMMARY.md
+++ b/zh-CN/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-- [关于 pracitce.rs](why-exercise.md)
+- [关于 practice.rs](why-exercise.md)
 - [值得学习的小型项目](elegant-code-base.md)
 - [变量绑定与解构](variables.md)
 - [基本类型](basic-types/intro.md)


### PR DESCRIPTION
emmm same question.
 - https://github.com/sunface/rust-by-practice/pull/310
 这个改动会影响到 https://zh.practice.rs/why-exercise.html 简体中文的第一章目录名，去年就发现了，刚无意瞅了一眼发现还没改过来=。=