### PR TITLE
Add check to <static.md> #2

### DIFF
--- a/en/src/lifetime/static.md
+++ b/en/src/lifetime/static.md
@@ -53,6 +53,7 @@ fn init() -> Option<&'static mut Config> {
 fn main() {
     unsafe {
         config = init();
+        if config.is_none() {panic!("`None` isn't solution to this exercise")};
 
         println!("{:?}",config)
     }


### PR DESCRIPTION
Currently just making `init()` return `None` gives trivial solution.