### PR TITLE
Grammatical change from needs to requires

### DIFF
--- a/en/src/pattern-match/patterns.md
+++ b/en/src/pattern-match/patterns.md
@@ -101,7 +101,7 @@ fn main() {
 }
 ```
 
-6. 🌟🌟 Using pattern `&mut V` to match a mutable reference needs you to be very careful, due to `V` being a value  after matching.
+6. 🌟🌟 Using pattern `&mut V` to match a mutable reference requires you to be very careful, due to `V` being a value  after matching.
 ```rust,editable
 
 // FIX the error with least changing

--- a/en/src/pattern-match/patterns.md
+++ b/en/src/pattern-match/patterns.md
@@ -102,6 +102,7 @@ fn main() {
 ```
 
 6. 🌟🌟 Using pattern `&mut V` to match a mutable reference requires you to be very careful, due to `V` being a value  after matching.
+
 ```rust,editable
 
 // FIX the error with least changing


### PR DESCRIPTION
Both sentences are grammatically correct, as the verbs "requires" and "needs" can be used interchangeably in this context. However, the first sentence sounds more formal and **is more commonly used in written English**, especially in technical or academic contexts.

In the context of your sentences (which are about programming), the first sentence:

"Using pattern &mut V to match a mutable reference requires you to be very careful, due to V being a value after matching"

sounds more suitable. It implies that the action (using the pattern &mut V) necessitates caution on the part of the user, due to the specific circumstance (that V becomes a value after matching).

The second sentence:

"Using pattern &mut V to match a mutable reference needs you to be very careful, due to V being a value after matching"

is also correct but it sounds slightly less formal and is **less commonly used in this kind of context.**