### PR TITLE
Fix editability of tasks in `iterator.md`

### DIFF
--- a/en/src/functional-programing/iterator.md
+++ b/en/src/functional-programing/iterator.md
@@ -223,7 +223,7 @@ Some of these methods call the method `next`to use up the iterator, so they are 
 
 8. 🌟🌟
 
-```rust,edtiable
+```rust,editable
 
 /* Fill in the blank and fix the errors */
 fn main() {

--- a/en/src/functional-programing/iterator.md
+++ b/en/src/functional-programing/iterator.md
@@ -287,7 +287,7 @@ fn main() {
 
 11. 🌟🌟
 
-```rust
+```rust,editable
 /* Fill in the blanks */
 use std::collections::HashMap;
 fn main() {
@@ -305,7 +305,7 @@ fn main() {
 
 12. 🌟🌟 
 
-```rust
+```rust,editable
 /* Fill in the blanks */
 #[derive(PartialEq, Debug)]
 struct Shoe {


### PR DESCRIPTION
- fix typo `edtiable` -> `editable` in task 8
- add `editable` to tasks 11 and 12
- fixes #370