### PR TITLE
Fixed Footer `giscus` Comments Widget

### DIFF
--- a/en/assets/custom3.js
+++ b/en/assets/custom3.js
@@ -147,7 +147,7 @@ var initAll = function () {
     script.setAttribute("data-emit-metadata", "0");
     script.setAttribute("data-input-position", "top");
     script.setAttribute("data-theme", theme);
-    script.setAttribute("data-lang", lang);
+    script.setAttribute("data-lang", lang == 'en-US' ? 'en' : lang);
     // 预先加载评论会更好，这样用户读到那边时，评论就加载好了
     // script.setAttribute("data-loading", "lazy");
     document.getElementById("giscus-container").appendChild(script);

--- a/zh-CN/assets/custom3.js
+++ b/zh-CN/assets/custom3.js
@@ -147,7 +147,7 @@ var initAll = function () {
     script.setAttribute("data-emit-metadata", "0");
     script.setAttribute("data-input-position", "top");
     script.setAttribute("data-theme", theme);
-    script.setAttribute("data-lang", lang);
+    script.setAttribute("data-lang", lang == 'en-US' ? 'en' : lang);
     // 预先加载评论会更好，这样用户读到那边时，评论就加载好了
     // script.setAttribute("data-loading", "lazy");
     document.getElementById("giscus-container").appendChild(script);


### PR DESCRIPTION
Giscus was not working due to an incorrect `data-lang` attribute value. According to [giscus documentation](https://giscus.app/)  `en-US` language is not supported. It should be `en` for English and `zh-CN` for Chinese.

Current live version;
![image](https://github.com/sunface/rust-by-practice/assets/38698087/0488e487-9dc2-4c6d-aeba-b6986bbfbdb7)


Now it's changed to;
![image](https://github.com/sunface/rust-by-practice/assets/38698087/513ab884-57f4-427f-b5e4-93a9a954505e)
