### PR TITLE
change solution for problem 2 of compound-types/slice to make it platform-independent.

### DIFF
--- a/solutions/compound-types/slice.md
+++ b/solutions/compound-types/slice.md
@@ -18,7 +18,9 @@ fn main() {
     let slice = &arr[..2];
 
     // TIPS: slice( reference ) IS NOT an array, because if it is, then `assert!` will passed: each of the two UTF-8 chars '中' and '国'  occupies 4 bytes, 2 * 4 = 8
-    assert!(std::mem::size_of_val(&slice) == 16);
+    let size_of_pointer = std::mem::size_of::<*const ()>();		// 8 on x86_64
+    let size_of_length = std::mem::size_of::<usize>();			// 8 on x86_64
+    assert!(std::mem::size_of_val(&slice) == size_of_pointer + size_of_length);
 }
 ```
 


### PR DESCRIPTION
hi,感谢您的电子书,我学到了很多.
针对compound-types/slice中的第2题目,有一些建议: 正如题目所说, 指针的内存大小 和 usize的内存大小 与平台实现有关,因此建议将slice的内存大小表示为这两个类型内存大小之和,以便跨平台.