### PR TITLE
git clone HTTPS URL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,7 @@ We use [mdbook](https://rust-lang.github.io/mdBook/) building our exercises. You
 
 - Clone the repo
 ```shell
-$ git clone git@github.com:sunface/rust-by-practice.git
+$ git clone https://github.com/sunface/rust-by-practice
 ```
 - Install mdbook using Cargo
 ```shell

--- a/en/src/why-exercise.md
+++ b/en/src/why-exercise.md
@@ -23,7 +23,7 @@ This book was designed for easily diving into and get skilled with Rust, and it'
 
 We use [mdbook](https://rust-lang.github.io/mdBook/) building our exercises. You can run locally with below steps:
 ```shell
-$ git clone git@github.com:sunface/rust-by-practice.git
+$ git clone https://github.com/sunface/rust-by-practice
 $ cargo install mdbook
 $ cd rust-by-practice && mdbook serve en/ 
 ```

--- a/zh-CN/src/why-exercise.md
+++ b/zh-CN/src/why-exercise.md
@@ -23,7 +23,7 @@
 
 我们使用 [mdbook](https://rust-lang.github.io/mdBook/) 构建在线练习题，你也可以下载到本地运行：
 ```shell
-$ git clone git@github.com:sunface/rust-by-practice.git
+$ git clone https://github.com/sunface/rust-by-practice
 $ cargo install mdbook
 $ cd rust-by-practice && mdbook serve zh-CN/
 ```


### PR DESCRIPTION
Changed the _git clone URL_ into an URL that is available to all people that have Internet access.