### PR TITLE
fix typo: 'assotiated' -> 'associated'

### DIFF
--- a/en/src/method.md
+++ b/en/src/method.md
@@ -195,7 +195,7 @@ struct TrafficLight {
 }
 
 impl TrafficLight {
-    // 1. Implement an assotiated function `new`,
+    // 1. Implement an associated function `new`,
     // 2. It will return a TrafficLight contains color "red"
     // 3. Must use `Self`, DONT use `TrafficLight` in fn signatures or body
     pub fn new() 

--- a/solutions/method.md
+++ b/solutions/method.md
@@ -75,7 +75,7 @@ struct TrafficLight {
 }
 
 impl TrafficLight {
-    // 1. implement a assotiated function `new`,
+    // 1. implement a associated function `new`,
     // 2. it will return a TrafficLight contains color "red"
     // 3. must use `Self`, DONT use `TrafficLight`
     pub fn new() -> Self {


### PR DESCRIPTION
hi,作者你好,我发现一个typo,望采纳