### PR TITLE
fix typo: in generics-traits/traits, change the name of variable `_this_is_true` to its intended name of `_this_is_false`.

### DIFF
--- a/en/src/generics-traits/traits.md
+++ b/en/src/generics-traits/traits.md
@@ -143,7 +143,7 @@ fn main() {
 
     println!("One second looks like: {:?}", _one_second);
     let _this_is_true = (_one_second == _one_second);
-    let _this_is_true = (_one_second > _one_second);
+    let _this_is_false = (_one_second > _one_second);
 
     let foot = Inches(12);
 

--- a/solutions/generics-traits/traits.md
+++ b/solutions/generics-traits/traits.md
@@ -66,7 +66,7 @@ fn main() {
 
     println!("One second looks like: {:?}", _one_second);
     let _this_is_true = (_one_second == _one_second);
-    let _this_is_true = (_one_second > _one_second);
+    let _this_is_false = (_one_second > _one_second);
 
     let foot = Inches(12);
 

--- a/zh-CN/src/generics-traits/traits.md
+++ b/zh-CN/src/generics-traits/traits.md
@@ -144,7 +144,7 @@ fn main() {
 
     println!("One second looks like: {:?}", _one_second);
     let _this_is_true = _one_second == _one_second;
-    let _this_is_true = _one_second > _one_second;
+    let _this_is_false = _one_second > _one_second;
 
     let foot = Inches(12);
 


### PR DESCRIPTION
hi,作者您好,感谢您的书籍,我学到了很多.
变量`_this_is_true`,按照代码原意,应该为`_this_is_false`,望采纳