### PR TITLE
fix: Correct the wrong answer to Exercise 11 in Chapter borrowing

### DIFF
--- a/solutions/ownership/borrowing.md
+++ b/solutions/ownership/borrowing.md
@@ -149,6 +149,6 @@ fn main() {
 
     // add one line below to make a compiler error: cannot borrow `s` as mutable more than once at a time
     // you can't use r1 and r2 at the same time
-    r1.push_str("world");
+    println!("{}, {}", r1, r2);
 }
 ```


### PR DESCRIPTION
Calling only r1 in the new compiler version does not trigger a reborrowing error