### PR TITLE
Update result.md，修改了错别字：zh-CN/src/result-panic/result.md，第5题“简介”->”简洁“

### DIFF
--- a/zh-CN/src/result-panic/result.md
+++ b/zh-CN/src/result-panic/result.md
@@ -125,7 +125,7 @@ fn multiply(n1_str: &str, n2_str: &str) -> Result<i32, ParseIntError> {
     }
 }
 
-// 重写上面的 `multiply` ，让它尽量简介
+// 重写上面的 `multiply` ，让它尽量简洁
 // 提示：使用 `and_then` 和 `map`
 fn multiply1(n1_str: &str, n2_str: &str) -> Result<i32, ParseIntError> {
     // 实现...


### PR DESCRIPTION
”// 重写上面的 `multiply` ，让它尽量简介“注释中的‘简介’->‘简洁’