### PR TITLE
Correct variable name inside the comment on the for loop.

### DIFF
--- a/en/src/flow-control.md
+++ b/en/src/flow-control.md
@@ -72,7 +72,7 @@ fn main() {
     let numbers = [1, 2, 3];
     // The elements in numbers are Copy，so there is no move here
     for n in numbers {
-        // Do something with name...
+        // Do something with n...
     }
     
     println!("{:?}", numbers);


### PR DESCRIPTION
Correct variable name inside comment on the for loop by replacing name with n inside the comment. 