### PR TITLE
Change Pair creation code on the Traits src and solution files.

### DIFF
--- a/en/src/generics-traits/traits.md
+++ b/en/src/generics-traits/traits.md
@@ -376,10 +376,7 @@ impl<T: std::fmt::Debug + PartialOrd> Pair<T> {
 struct Unit(i32);
 
 fn main() {
-    let pair = Pair{
-        x: Unit(1),
-        y: Unit(3)
-    };
+    let pair = Pair::new(Unit(1), Unit(2)); 
 
     pair.cmp_display();
 }

--- a/solutions/generics-traits/traits.md
+++ b/solutions/generics-traits/traits.md
@@ -335,10 +335,7 @@ impl<T: std::fmt::Debug + PartialOrd> Pair<T> {
 struct Unit(i32);
 
 fn main() {
-    let pair = Pair{
-        x: Unit(1),
-        y: Unit(3)
-    };
+    let pair = Pair::new(Unit(1), Unit(2));
 
     pair.cmp_display();
 }


### PR DESCRIPTION
Change the code to use the 'new' associated function instead create the Struct with the curly brackets syntax.