### PR TITLE
不加vec!的话会有以下报错。

### DIFF
--- a/solutions/collections/Vector.md
+++ b/solutions/collections/Vector.md
@@ -104,6 +104,10 @@ fn main() {
     let v3 = Vec::from(s);
     assert_eq!(v2, v3);
 
+    // 迭代器 Iterators 可以通过 collect 变成 Vec
+    let v4: Vec<i32> = vec![0; 10].into_iter().collect();
+    assert_eq!(v4, vec![0; 10]);
+
     println!("Success!")
  }
 ```

--- a/zh-CN/src/collections/vector.md
+++ b/zh-CN/src/collections/vector.md
@@ -83,7 +83,7 @@ fn main() {
     assert_eq!(v2, v3);
 
     // 迭代器 Iterators 可以通过 collect 变成 Vec
-    let v4: Vec<i32> = [0; 10].into_iter().collect();
+    let v4: Vec<i32> = vec![0; 10].into_iter().collect();
     assert_eq!(v4, vec![0; 10]);
 
     println!("Success!")


### PR DESCRIPTION
error[E0277]: a value of type `Vec<i32>` cannot be built from an iterator over elements of type `&{integer}`
    --> main.rs:26:44
     |
26   |     let v4: Vec<i32> = [0; 10].into_iter().collect();
     |                                            ^^^^^^^ value of type `Vec<i32>` cannot be built from `std::iter::Iterator<Item=&{integer}>`
     |
     = help: the trait `FromIterator<&{integer}>` is not implemented for `Vec<i32>`
     = help: the trait `FromIterator<T>` is implemented for `Vec<T>`
note: the method call chain might not have had the expected associated types
    --> main.rs:26:32
     |
26   |     let v4: Vec<i32> = [0; 10].into_iter().collect();
     |                        ------- ^^^^^^^^^^^ `Iterator::Item` is `&{integer}` here
     |                        |
     |                        this expression has type `[{integer}; 10]`
note: required by a bound in `collect`
    --> /Users/hible/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2049:19
     |
2049 |     fn collect<B: FromIterator<Self::Item>>(self) -> B
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::collect`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
