### PR TITLE
add trim for Q3 of type-conversions

### DIFF
--- a/zh-CN/src/type-conversions/others.md
+++ b/zh-CN/src/type-conversions/others.md
@@ -61,6 +61,7 @@ impl FromStr for Point {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let coords: Vec<&str> = s.trim_matches(|p| p == '(' || p == ')' )
                                  .split(',')
+                                 .map(|x| x.trim())
                                  .collect();
 
         let x_fromstr = coords[0].parse::<i32>()?;


### PR DESCRIPTION
add `.map(|x| x.trim()) ` for Q3 of type-conversions 
增加`"3, 4"`答案中有空格的情况