### PR TITLE
Correction of problem 1 in vector.md

### DIFF
--- a/en/src/collections/vector.md
+++ b/en/src/collections/vector.md
@@ -9,26 +9,26 @@ fn main() {
     let arr: [u8; 3] = [1, 2, 3];
     
     let v = Vec::from(arr);
-    is_vec(v);
+    is_vec(&v);
 
     let v = vec![1, 2, 3];
-    is_vec(v);
+    is_vec(&v);
 
     // vec!(..) and vec![..] are same macros, so
     let v = vec!(1, 2, 3);
-    is_vec(v);
+    is_vec(&v);
     
     // In code below, v is Vec<[u8; 3]> , not Vec<u8>
     // USE Vec::new and `for` to rewrite the below code 
     let v1 = vec!(arr);
-    is_vec(v1);
+    is_vec(&v1);
  
     assert_eq!(v, v1);
 
     println!("Success!");
 }
 
-fn is_vec(v: Vec<u8>) {}
+fn is_vec(v: &Vec<u8>) {}
 ```
 
 


### PR DESCRIPTION
v is not accessible to copy the values to v1 if the ownership is moved to is_vec().

The code in the corresponding answer is correct.