### PR TITLE
add "3, 4" answers with Spaces for Q3 of type-conversions/others

### DIFF
--- a/en/src/type-conversions/others.md
+++ b/en/src/type-conversions/others.md
@@ -60,6 +60,7 @@ impl FromStr for Point {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let coords: Vec<&str> = s.trim_matches(|p| p == '(' || p == ')' )
                                  .split(',')
+                                 .map(|x| x.trim())
                                  .collect();
 
         let x_fromstr = coords[0].parse::<i32>()?;


### PR DESCRIPTION
add `.map(|x| x.trim())`  for Q3 of type-conversions/others, Added "3, 4" answers with Spaces