### PR TITLE
fixed typo in functions qn3 work

### DIFF
--- a/en/src/basic-types/functions.md
+++ b/en/src/basic-types/functions.md
@@ -35,7 +35,7 @@ fn print() -> i32 {
 
 ```rust,editable
 // Solve it in two ways
-// DON'T let `println!` works
+// DON'T let `println!` work
 fn main() {
     never_return();
 


### PR DESCRIPTION
fixed typo to use base form verb