### PR TITLE
fix: reference to Lifetime Learning Resource(English) fixed

### DIFF
--- a/en/src/lifetime/intro.md
+++ b/en/src/lifetime/intro.md
@@ -1,5 +1,5 @@
 # Lifetime
 Learning resources: 
-- English: [Rust Book 10.3](https://doc.rust-lang.org/book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html)
+- English: [Rust Book 10.3](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)
 - 简体中文: [Rust语言圣经 - 生命周期](https://course.rs/advance/lifetime/intro.html)
 


### PR DESCRIPTION
Modified the hyperlink to English learning resource for Lifetime topic