### PR TITLE
Update basic.md

### DIFF
--- a/solutions/lifetime/basic.md
+++ b/solutions/lifetime/basic.md
@@ -225,7 +225,7 @@ fn nput(x: &i32) {
 
 fn pass(x: &i32) -> &i32 { x }
 
-fn longest<'a, 'b>(x: &'a str, y: &'b str) -> &'a str {
+fn longest<'a>(x: &'a str, y: &str) -> &'a str {
     x
 }
 


### PR DESCRIPTION
`y` 与输出无关，可以移除其生命周期标注。