### PR TITLE
Rename first_word to first_letter

### DIFF
--- a/en/src/compound-types/slice.md
+++ b/en/src/compound-types/slice.md
@@ -84,15 +84,15 @@ fn main() {
 fn main() {
     let mut s = String::from("hello world");
 
-    // Here, &s is `&String` type, but `first_word` need a `&str` type.
+    // Here, &s is `&String` type, but `first_letter` needs a `&str` type.
     // It works because `&String` can be implicitly converted to `&str. If you want to know more, this is called `Deref coercion`. 
-    let word = first_word(&s);
+    let letter = first_letter(&s);
 
     s.clear(); // error!
 
-    println!("the first word is: {}", word);
+    println!("the first letter is: {}", letter);
 }
-fn first_word(s: &str) -> &str {
+fn first_letter(s: &str) -> &str {
     &s[..1]
 }
 ```

--- a/solutions/compound-types/slice.md
+++ b/solutions/compound-types/slice.md
@@ -62,16 +62,16 @@ fn main() {
 fn main() {
     let mut s = String::from("hello world");
 
-    // here, &s is `&String` type, but `first_word` need a `&str` type.
+    // here, &s is `&String` type, but `first_letter` needs a `&str` type.
     // it works because `&String` can be implicitly converted to `&str, If you want know more ,this is called `Deref` 
-    let word = first_word(&s);
+    let letter = first_letter(&s);
 
-    println!("the first word is: {}", word);
+    println!("the first letter is: {}", letter);
 
     s.clear();
 }
 
-fn first_word(s: &str) -> &str {
+fn first_letter(s: &str) -> &str {
     &s[..1]
 }
 ```


### PR DESCRIPTION
The function name is confusing as it implies the function (should?) return "hello" (first word) - but it returns only the first letter (or char) - "h".

This rename makes it less confusing.