### PR TITLE
fix string.md

### DIFF
--- a/solutions/compound-types/string.md
+++ b/solutions/compound-types/string.md
@@ -19,17 +19,6 @@ fn main() {
  }
 ```
 
-```rust
-fn main() {
-    let s: Box<&str> = "hello, world".into();
-    greetings(*s)
-}
-
-fn greetings(s: &str) {
-    println!("{}", s);
-}
-```
-
 3.
 
 ```rust


### PR DESCRIPTION
The solution
```rust
fn main() {
    let s: Box<&str> = "hello, world".into();
    greetings(*s)
}

fn greetings(s: &str) {
    println!("{}", s);
}
```
was reported two times creating confusion