### PR TITLE
Fix Mutable slice content in Collection Types -> Vector -> Slicing

### DIFF
--- a/en/src/collections/vector.md
+++ b/en/src/collections/vector.md
@@ -130,7 +130,7 @@ fn main() {
     assert_eq!(slice1, slice2);
     
     // A slice can also be mutable, in which
-    // case mutating it will mutate its underlying Vec
+    // case mutating it will mutate its underlying Vec.
     // Note: slice and &Vec are different
     let vec_ref: &mut Vec<i32> = &mut v;
     (*vec_ref).push(4);

--- a/en/src/collections/vector.md
+++ b/en/src/collections/vector.md
@@ -111,7 +111,7 @@ fn main() {
 
 
 ### Slicing
-Immutable or mutable slices of Vecs can be taken, using `&` or `&mut, respectively.
+Immutable or mutable slices of Vecs can be taken, using `&` or `&mut`, respectively.
 
 In Rust, it’s more common to pass immutable slices as arguments rather than vectors when you just want to provide read access, as this is more flexible (no move) and efficient (no copy). The same goes for `String` and `&str`.
 

--- a/en/src/collections/vector.md
+++ b/en/src/collections/vector.md
@@ -111,9 +111,9 @@ fn main() {
 
 
 ### Slicing
-A Vec can be mutable. On the other hand, slices are read-only objects. To get a slice, use `&`. 
+Immutable or mutable slices of Vecs can be taken, using `&` or `&mut, respectively.
 
-In Rust, it’s more common to pass slices as arguments rather than vectors when you just want to provide read access. The same goes for `String` and `&str`.
+In Rust, it’s more common to pass immutable slices as arguments rather than vectors when you just want to provide read access. The same goes for `String` and `&str`.
 
 5. 🌟🌟
 ```rust,editable
@@ -129,14 +129,16 @@ fn main() {
     
     assert_eq!(slice1, slice2);
     
-    // Slices are read only
+    // Slices can also be mutable, in which
+    // case mutating them will mutate the underlying Vec
     // Note: slice and &Vec are different
     let vec_ref: &mut Vec<i32> = &mut v;
     (*vec_ref).push(4);
     let slice3 = &mut v[0..3];
-    slice3.push(4);
+    slice3[3] = 42;
 
-    assert_eq!(slice3, &[1, 2, 3, 4]);
+    assert_eq!(slice3, &[1, 2, 3, 42]);
+    assert_eq!(v, &[1, 2, 3, 42]);
 
     println!("Success!");
 }

--- a/en/src/collections/vector.md
+++ b/en/src/collections/vector.md
@@ -129,8 +129,8 @@ fn main() {
     
     assert_eq!(slice1, slice2);
     
-    // Slices can also be mutable, in which
-    // case mutating them will mutate the underlying Vec
+    // A slice can also be mutable, in which
+    // case mutating it will mutate its underlying Vec
     // Note: slice and &Vec are different
     let vec_ref: &mut Vec<i32> = &mut v;
     (*vec_ref).push(4);

--- a/en/src/collections/vector.md
+++ b/en/src/collections/vector.md
@@ -113,7 +113,7 @@ fn main() {
 ### Slicing
 Immutable or mutable slices of Vecs can be taken, using `&` or `&mut, respectively.
 
-In Rust, it’s more common to pass immutable slices as arguments rather than vectors when you just want to provide read access. The same goes for `String` and `&str`.
+In Rust, it’s more common to pass immutable slices as arguments rather than vectors when you just want to provide read access, as this is more flexible (no move) and efficient (no copy). The same goes for `String` and `&str`.
 
 5. 🌟🌟
 ```rust,editable

--- a/solutions/collections/Vector.md
+++ b/solutions/collections/Vector.md
@@ -156,21 +156,24 @@ fn main() {
     let mut v = vec![1, 2, 3];
 
     let slice1 = &v[..];
-    // out of bounds will cause a panic
+    // Out of bounds will cause a panic
     // You must use `v.len` here
-    let slice2 = &v[0..v.len()];
+    let slice2 = &v[0..3];
     
     assert_eq!(slice1, slice2);
     
-    // slice are read only
+    // A slice can also be mutable, in which
+    // case mutating it will also mutate its underlying Vec
     // Note: slice and &Vec are different
     let vec_ref: &mut Vec<i32> = &mut v;
     (*vec_ref).push(4);
-    let slice3 = &mut v[0..];
+    let slice3 = &mut v[0..4];
+    slice3[3] = 42;
 
-    assert_eq!(slice3, &[1, 2, 3, 4]);
+    assert_eq!(slice3, &[1, 2, 3, 42]);
+    assert_eq!(v, &[1, 2, 3, 42]);
 
-    println!("Success!")
+    println!("Success!");
 }
 ```
 


### PR DESCRIPTION
At present the content on slices in Collection Types -> Vector -> Slicing[0][1][2] is inaccurate with respect to mutable slices: it says that slices are read-only, but that is not the case. A mutable slice of a Vec can be taken, then mutated, which will affect the slice itself as well as its underlying Vec.

The immediate reason the code below, excerpted from exercise 5 (with the slice's ending index fixed: `3` -> `4`), does not work, is that the `push()` method is not defined for `slice3`'s type (`&mut [i32]`):

```rust

    let vec_ref: &mut Vec<i32> = &mut v;
    (*vec_ref).push(4);
    let slice3 = &mut v[0..4];
    slice3.push(4);

```

this is explained by the error the compiler reports:

```
Compiling playground v0.0.1 (/playground)
error[E0599]: no method named `push` found for mutable reference `&mut [i32]` in the current scope
  --> src/main.rs:18:12
   |
18 |     slice3.push(4);
   |            ^^^^ method not found in `&mut [i32]`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `playground` (bin "playground") due to 1 previous error

```

We can instead, however, mutate a mutable slice by indexing into it, for example:

```rust

fn main() {
    let mut v = vec![1, 2, 3];

    let vec_ref: &mut Vec<i32> = &mut v;
    (*vec_ref).push(4);
    let slice3 = &mut v[0..4];

    //slice3 is a mutable reference, so the code below
    // will also mutate the underlying Vec
    slice3[3] = 42;

    // we need to print slice3 and v in that order,
    // since a live mutable borrow (in this case slice3) prevents the use
    // of the value it borrowed from (v)
    println!("{:?}", slice3); // prints [1, 2, 3, 42]
    println!("{:?}", v); // prints [1, 2, 3, 42]
}

```

I made edits to `en/src/collections/vector.md` and `solutions/collections/Vector.md` to try and reflect what I wrote above, while preserving the point I think the section was trying to make, about the advantages of passing in immutable slices rather than `Vec`s as arguments to functions.


- - -

[0] English URL: https://practice.course.rs/collections/vector.html#slicing
[1] the code starts at: https://github.com/sunface/rust-by-practice/blob/9fb657287ff9c460de179e580c7c8a17ae60c51d/en/src/collections/vector.md?plain=1#L113
[2] the code of the matching solution starts at https://github.com/sunface/rust-by-practice/blob/9fb657287ff9c460de179e580c7c8a17ae60c51d/solutions/collections/Vector.md?plain=1#L151