### PR TITLE
Fix typo to make the Iterator section's exercise 8 editable in the browser

### DIFF
--- a/en/src/functional-programing/iterator.md
+++ b/en/src/functional-programing/iterator.md
@@ -223,7 +223,7 @@ Some of these methods call the method `next`to use up the iterator, so they are 
 
 8. 🌟🌟
 
-```rust,edtiable
+```rust,editable
 
 /* Fill in the blank and fix the errors */
 fn main() {


### PR DESCRIPTION
The Iterator section's [8th exercise](https://practice.course.rs/functional-programing/iterator.html#consuming-adaptors) is currently uneditable in the browser owing to a small typo in its source, which has `edtiable` instead of the correct `editable`. This PR fixes the typo to make the code editable.