### PR TITLE
Update numbers.md – clear up instructions about printing range of ASCII characters

### DIFF
--- a/en/src/basic-types/numbers.md
+++ b/en/src/basic-types/numbers.md
@@ -120,7 +120,7 @@ fn main() {
 ```
 
 ### Range
-9. 🌟🌟 Two goals: 1. Modify `assert!` to make it work 2. Make `println!` output: 97 - 122
+9. 🌟🌟 Two goals: 1. Modify `assert!` to make it work 2. Make `println!` output list of numbers between 97 and 122
 
 ```rust,editable
 fn main() {


### PR DESCRIPTION
I was really confused, why should I print out the result of subtracting two numbers in a loop (even though I'm very much aware of the ASCII characters). I hope it makes things a bit clearer.