### PR TITLE
修改题目使其目的更明确

### DIFF
--- a/en/src/generics-traits/const-generics.md
+++ b/en/src/generics-traits/const-generics.md
@@ -117,15 +117,15 @@ fn main() {
 
 fn check_size<T>(val: T)
 where
-    Assert<{ core::mem::size_of::<T>() < 768 }>: IsTrue,
+    Assert<{ core::mem::size_of::<T>() == 768 }>: IsTrue,
 {
     //...
 }
 
 // Fix the errors in main.
 fn main() {
-    check_size([0u8; 767]); 
-    check_size([0i32; 191]);
+    check_size([0u8; 768]); 
+    check_size([0i32; 192]);
     check_size(["hello你好"; __]); // Size of &str ?
     check_size([(); __].map(|_| "hello你好".to_string()));  // Size of String?
     check_size(['中'; __]); // Size of char ?

--- a/solutions/generics-traits/const-generics.md
+++ b/solutions/generics-traits/const-generics.md
@@ -43,18 +43,18 @@ fn main() {
 
 fn check_size<T>(val: T)
 where
-    Assert<{ core::mem::size_of::<T>() < 768 }>: IsTrue,
+    Assert<{ core::mem::size_of::<T>() == 768 }>: IsTrue,
 {
     //...
 }
 
 // fix the errors in main
 fn main() {
-    check_size([0u8; 767]); 
-    check_size([0i32; 191]);
-    check_size(["hello你好"; 47]); // &str is a string reference, containing a pointer and string length in it, so it takes two word long, in x86-64, 1 word = 8 bytes
-    check_size([(); 31].map(|_| "hello你好".to_string()));  // String is a smart pointer struct, it has three fields: pointer, length and capacity, each takes 8 bytes
-    check_size(['中'; 191]); // A char takes 4 bytes in Rust
+    check_size([0u8; 768]); 
+    check_size([0i32; 192]);
+    check_size(["hello你好"; 48]); // &str is a string reference, containing a pointer and string length in it, so it takes two word long, in x86-64, 1 word = 8 bytes
+    check_size([(); 32].map(|_| "hello你好".to_string()));  // String is a smart pointer struct, it has three fields: pointer, length and capacity, each takes 8 bytes
+    check_size(['中'; 192]); // A char takes 4 bytes in Rust
 }
 
 

--- a/zh-CN/src/generics-traits/const-generics.md
+++ b/zh-CN/src/generics-traits/const-generics.md
@@ -113,15 +113,15 @@ fn main() {
 
 fn check_size<T>(val: T)
 where
-    Assert<{ core::mem::size_of::<T>() < 768 }>: IsTrue,
+    Assert<{ core::mem::size_of::<T>() == 768 }>: IsTrue,
 {
     //...
 }
 
 // 修复 main 函数中的错误
 fn main() {
-    check_size([0u8; 767]); 
-    check_size([0i32; 191]);
+    check_size([0u8; 768]); 
+    check_size([0i32; 192]);
     check_size(["hello你好"; __]); // size of &str ?
     check_size([(); __].map(|_| "hello你好".to_string()));  // size of String?
     check_size(['中'; __]); // size of char ?


### PR DESCRIPTION
使用

```rust
Assert<{ core::mem::size_of::<T>() < 768 }>: IsTrue,
```

导致题目目的不明确

修改为

```rust
Assert<{ core::mem::size_of::<T>() == 768 }>: IsTrue,
```