### PR TITLE
Update links to reflect domain change

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ This book was designed for easily diving into and getting skilled with Rust It's
 
 ## Reading online
 
-- [https://practice.rs](https://practice.rs)
+- [https://practice.course.rs](https://practice.course.rs)
 
 ## Features
 

--- a/en/src/generics-traits/trait-object.md
+++ b/en/src/generics-traits/trait-object.md
@@ -1,5 +1,5 @@
 # Trait Object
-In [traits chapter](https://practice.rs/generics-traits/traits.html#returning-types-that-implement-traits) we have seen that we can't use `impl Trait` when returning multiple types.
+In [traits chapter](https://practice.course.rs/generics-traits/traits.html#returning-types-that-implement-traits) we have seen that we can't use `impl Trait` when returning multiple types.
 
 Another limitation of arrays is that they can only store elements of one type. Using enums is not a bad solution when we have a fixed set of types at compile time, but trait objects would be more flexible and powerful.
 

--- a/en/src/type-conversions/others.md
+++ b/en/src/type-conversions/others.md
@@ -80,7 +80,7 @@ fn main() {
 ```
 
 ### Deref
-You can find all the examples and exercises of the `Deref` trait [here](https://practice.rs/smart-pointers/deref.html).
+You can find all the examples and exercises of the `Deref` trait [here](https://practice.course.rs/smart-pointers/deref.html).
 
 ### Transmute
 `std::mem::transmute` is a **unsafe function** can be used to reinterprets the bits of a value of one type as another type. Both of the original and the result types must have the same size and neither of them can be invalid.

--- a/en/src/why-exercise.md
+++ b/en/src/why-exercise.md
@@ -15,8 +15,8 @@ This book was designed for easily diving into and getting skilled with Rust, and
 
 ## Reading online
 
-- [English](https://practice.rs)
-- [简体中文](https://zh.practice.rs)
+- [English](https://practice.course.rs)
+- [简体中文](https://practice-zh.course.rs/)
 
 
 ## Running locally

--- a/practices/doc-comments/Readme.md
+++ b/practices/doc-comments/Readme.md
@@ -1,2 +1,2 @@
 ## Doc comments
-A practice project used in [Comments and Docs](https://practice.rs/comments-docs.html) chapter.
+A practice project used in [Comments and Docs](https://practice.course.rs/comments-docs.html) chapter.

--- a/practices/hello-package/Readme.md
+++ b/practices/hello-package/Readme.md
@@ -1,5 +1,5 @@
 ## Hello Package
-A practice project used in [Crate and Module](https://practice.rs/crate-module/crate.html) chapter.
+A practice project used in [Crate and Module](https://practice.course.rs/crate-module/crate.html) chapter.
 
 This project will guide us to create a package with a binary crate and several library crates in it.
 

--- a/zh-CN/src/generics-traits/trait-object.md
+++ b/zh-CN/src/generics-traits/trait-object.md
@@ -1,5 +1,5 @@
 # 特征对象
-在[特征练习中](https://practice.course.rs/generics-traits/traits.html#returning-types-that-implement-traits) 我们已经知道当函数返回多个类型时，`impl Trait` 是无法使用的。
+在[特征练习中](https://practice-zh.course.rs/generics-traits/traits.html#returning-types-that-implement-traits) 我们已经知道当函数返回多个类型时，`impl Trait` 是无法使用的。
 
 对于数组而言，其中一个限制就是无法存储不同类型的元素，但是通过之前的学习，大家应该知道枚举可以在部分场景解决这种问题，但是这种方法局限性较大。此时就需要我们的主角登场了。
 

--- a/zh-CN/src/generics-traits/trait-object.md
+++ b/zh-CN/src/generics-traits/trait-object.md
@@ -1,5 +1,5 @@
 # 特征对象
-在[特征练习中](https://practice.rs/generics-traits/traits.html#returning-types-that-implement-traits) 我们已经知道当函数返回多个类型时，`impl Trait` 是无法使用的。
+在[特征练习中](https://practice.course.rs/generics-traits/traits.html#returning-types-that-implement-traits) 我们已经知道当函数返回多个类型时，`impl Trait` 是无法使用的。
 
 对于数组而言，其中一个限制就是无法存储不同类型的元素，但是通过之前的学习，大家应该知道枚举可以在部分场景解决这种问题，但是这种方法局限性较大。此时就需要我们的主角登场了。
 

--- a/zh-CN/src/type-conversions/others.md
+++ b/zh-CN/src/type-conversions/others.md
@@ -81,7 +81,7 @@ fn main() {
 ```
 
 ### Deref 特征
-Deref 特征在[智能指针 - Deref](https://practice.course.rs/smart-pointers/deref.html)章节中有更加详细的介绍。
+Deref 特征在[智能指针 - Deref](https://practice-zh.course.rs/smart-pointers/deref.html)章节中有更加详细的介绍。
 
 ### transmute
 `std::mem::transmute` 是一个 unsafe 函数，可以把一个类型按位解释为另一个类型，其中这两个类型必须有同样的位数( bits )。

--- a/zh-CN/src/type-conversions/others.md
+++ b/zh-CN/src/type-conversions/others.md
@@ -81,7 +81,7 @@ fn main() {
 ```
 
 ### Deref 特征
-Deref 特征在[智能指针 - Deref](https://practice.rs/smart-pointers/deref.html)章节中有更加详细的介绍。
+Deref 特征在[智能指针 - Deref](https://practice.course.rs/smart-pointers/deref.html)章节中有更加详细的介绍。
 
 ### transmute
 `std::mem::transmute` 是一个 unsafe 函数，可以把一个类型按位解释为另一个类型，其中这两个类型必须有同样的位数( bits )。

--- a/zh-CN/src/why-exercise.md
+++ b/zh-CN/src/why-exercise.md
@@ -17,7 +17,7 @@
 
 ## 在线阅读
 
-- [https://zh.practice.rs](https://zh.practice.rs)
+- [https://practice-zh.course.rs/](https://practice-zh.course.rs/)
 
 ## 本地运行
 


### PR DESCRIPTION
## Summary

This PR updates links from `practice.rs` to `practice.course.rs` in English content, and from `zh.practice.rs` to `practice-zh.course.rs` in Chinese content.

## Changes

- Updated relevant links in Markdown files only.
- No other content was modified.

## Motivation

This change ensures that all references point to valid and current URLs, improving the accuracy and usability of the documentation.

## Other

All updated links have been tested and are accessible.